### PR TITLE
Allow more SignTool arguments to be customized

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -80,9 +80,9 @@ struct Args {
     #[arg(long, default_value = "SHA256")]
     td: String,
 
-    /// Description of the signed content
-    /// This description will appear as the .msi installer name in the UAC installation prompt and
-    /// will be a random string if unset.
+    /// Description of the signed content.
+    /// When signing a .msi installer, this description will appear as the installer's name in the
+    /// UAC prompt or will be a random string of characters if unset.
     #[arg(long, short = 'd')]
     description: Option<String>,
 }


### PR DESCRIPTION
Fixes #5

This PR makes 4 arguments to SignTool.exe customizable: `/fd`, `/tr`, `/td`, `/d`. 

I had to unroll the `cmd!` macro which looks a bit ugly unfortunately since it doesn't support optional arguments.