### PR TITLE
Support AZURE_TRUSTED_SIGNING_ACCOUNT_NAME, AZURE_CERTIFICATE_PROFILE_NAME

### DIFF
--- a/READMe.md
+++ b/READMe.md
@@ -18,9 +18,11 @@ A simple CLI tool to sign files with Trusted Signing
 
 The CLI expects the following environment variables to be set or you can pass them as arguments. You need to create an Azure App Registration (you can use [this](https://learn.microsoft.com/en-us/power-apps/developer/data-platform/walkthrough-register-app-azure-active-directory) article to get the credentials):
 
--   `AZURE_CLIENT_ID`
--   `AZURE_CLIENT_SECRET`
--   `AZURE_TENANT_ID`
+-   `AZURE_CLIENT_ID` (or use `--azure-client-id`)
+-   `AZURE_CLIENT_SECRET` (or use `--azure-tenant-id`)
+-   `AZURE_TENANT_ID` (or use `--azure-tenant-id`)
+-   `AZURE_TRUSTED_SIGNING_ACCOUNT_NAME` (or use `--account/-a`)
+-   `AZURE_CERTIFICATE_PROFILE_NAME` (or use `--certificate/-c`)
 
 Signing a single file:
 `trusted-signing-cli -e <url> -a <account name> -c <certificate profile name> file1.exe`

--- a/READMe.md
+++ b/READMe.md
@@ -19,7 +19,7 @@ A simple CLI tool to sign files with Trusted Signing
 The CLI expects the following environment variables to be set or you can pass them as arguments. You need to create an Azure App Registration (you can use [this](https://learn.microsoft.com/en-us/power-apps/developer/data-platform/walkthrough-register-app-azure-active-directory) article to get the credentials):
 
 -   `AZURE_CLIENT_ID` (or use `--azure-client-id`)
--   `AZURE_CLIENT_SECRET` (or use `--azure-tenant-id`)
+-   `AZURE_CLIENT_SECRET` (or use `--azure-client-secret`)
 -   `AZURE_TENANT_ID` (or use `--azure-tenant-id`)
 -   `AZURE_TRUSTED_SIGNING_ACCOUNT_NAME` (or use `--account/-a`)
 -   `AZURE_CERTIFICATE_PROFILE_NAME` (or use `--certificate/-c`)

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,12 +60,20 @@ struct Args {
     #[arg(long, short = 'e', verbatim_doc_comment)]
     endpoint: String,
 
-    /// Code Signing Account name
-    #[arg(long, short = 'a')]
+    /// Trusted Signing Account name
+    #[arg(
+        long,
+        env = "AZURE_TRUSTED_SIGNING_ACCOUNT_NAME",
+        short = 'a'
+    )]
     account: String,
 
     /// Certificate Profile name
-    #[arg(long, short = 'c')]
+    #[arg(
+        long,
+        env = "AZURE_CERTIFICATE_PROFILE_NAME",
+        short = 'c'
+    )]
     certificate: String,
 
     /// File digest algorithm
@@ -107,6 +115,7 @@ async fn main() {
 }
 
 async fn run(args: Args) -> Result<(), String> {
+    dbg!(&args);
     if fs::metadata(&args.azure_cli_path).is_err() {
         Err(format!(
             "azure cli {} does not exists, please specify PATH with env AZURE_CLI_PATH",

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,7 +115,6 @@ async fn main() {
 }
 
 async fn run(args: Args) -> Result<(), String> {
-    dbg!(&args);
     if fs::metadata(&args.azure_cli_path).is_err() {
         Err(format!(
             "azure cli {} does not exists, please specify PATH with env AZURE_CLI_PATH",


### PR DESCRIPTION
First of all, thank you for this project, it's a huge help for our Tauri app distribution.

Following https://v2.tauri.app/distribute/sign/windows/#modify-your-tauriconfjson-file, we're setting:

```json
{
  "bundle": {
    "windows": {
      "signCommand": "trusted-signing-cli -e https://wus2.codesigning.azure.net -a MyAccount -c MyProfile -d MyApp %1"
    }
  }
}
```

While the account name (-a) and profile name (-c) values are scoped to the azure account, on principle we'd rather not disclose those in a public GitHub repo so we want to use GitHub secrets for these. Unfortunately, 

```json
"signCommand": "trusted-signing-cli -a %AZURE_TRUSTED_SIGNING_ACCOUNT_NAME% ... %1"
```

does not work because env vars are not expanded.

```json
"signCommand": {"cmd": "cmd.exe", "args": ["/c", "... %1"]}
```

does not work either because %1 is not being interpolated.

An existing workaround is to use a wrapper script, e.g.:

```json
"signCommand": "sign.bat %1"
```

however I'd rather avoid an external file and instead only maintain the workflow file, release.yml, and tauri.conf.json.